### PR TITLE
Cheerio Support

### DIFF
--- a/src/cheerio.js
+++ b/src/cheerio.js
@@ -1,0 +1,41 @@
+'use strict'
+
+const { chain, mapValues } = require('lodash')
+const { Cookie } = require('tough-cookie')
+
+const getCookies = str =>
+  chain(str)
+    .castArray()
+    .compact()
+    .map(str => Cookie.parse(str).toJSON())
+    .map(({ key: name, ...props }) => ({ name, ...props }))
+    .value()
+
+const getHeaders = headers => mapValues(headers, value => [value])
+
+const getScripts = $ =>
+  chain($('script'))
+    .map(s => s.attribs['src'])
+    .compact()
+    .uniq()
+    .value()
+
+const getMeta = $ =>
+  Array.from($('meta')).reduce((acc, meta) => {
+    const key = meta.attribs['name'] || meta.attribs['property']
+    if (key) acc[key.toLowerCase()] = [meta.attribs['content']]
+    return acc
+  }, {})
+
+module.exports = ({ wappalyzer, url, headers, $ }) => {
+  const detections = wappalyzer.analyze({
+    url,
+    meta: getMeta($),
+    headers: getHeaders(headers),
+    scripts: getScripts($),
+    cookies: getCookies(headers['set-cookie']),
+    html: $.html()
+  })
+
+  return wappalyzer.resolve(detections)
+}


### PR DESCRIPTION
Apify, a popular scraping library, consumes fetched pages using Cheerio. I don't have time for a proper PR, but this draft is working and allows you to pass a apify-generated cheerio reference in. Hopefully someone else can finish up this PR and get it merged in.