### PR TITLE
Updated headers['set-cookie'] to be case-insensitive

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,21 +44,22 @@ module.exports = ({ url, headers, html }) => {
   
   let cookies_lowerCase = null;
   var searchKey = 'set-cookie';
-  cookies_lowerCase = Object.keys(myObj).find(key => { 
+  cookies_lowerCase = headers[Object.keys(myObj).find(key => { 
       if(key.toLowerCase() === searchKey.toLowerCase()){
           //console.log("MATCH!!!");
           return true;
       }
-  })
+  })];
 
   const detections = wappalyzer.analyze({
     url,
     meta: getMeta(dom.window.document),
     headers: getHeaders(headers),
     scripts: getScripts(dom.window.document.scripts),
-    cookies: getCookies(headers['set-cookie']),
+    cookies: getCookies(cookies_lowerCase),
     html: dom.serialize()
   })
+
 
   return wappalyzer.resolve(detections)
 }

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ module.exports = ({ url, headers, html }) => {
   
   let cookies_lowerCase = null;
   var searchKey = 'set-cookie';
-  cookies_lowerCase = headers[Object.keys(myObj).find(key => { 
+  cookies_lowerCase = headers[Object.keys(headers).find(key => { 
       if(key.toLowerCase() === searchKey.toLowerCase()){
           //console.log("MATCH!!!");
           return true;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 'use strict'
-//test ed
+
 const { chain, mapValues } = require('lodash')
 const wappalyzer = require('wappalyzer-core')
 const { Cookie } = require('tough-cookie')
@@ -15,6 +15,7 @@ wappalyzer.setCategories(categories)
 const parseCookie = str => Cookie.parse(str).toJSON()
 
 const getCookies = str =>
+
   chain(str)
     .castArray()
     .compact()
@@ -40,6 +41,15 @@ const getMeta = document =>
 
 module.exports = ({ url, headers, html }) => {
   const dom = new JSDOM(html, { url, virtualConsole: new VirtualConsole() })
+  
+  let cookies_lowerCase = null;
+  var searchKey = 'set-cookie';
+  cookies_lowerCase = Object.keys(myObj).find(key => { 
+      if(key.toLowerCase() === searchKey.toLowerCase()){
+          //console.log("MATCH!!!");
+          return true;
+      }
+  })
 
   const detections = wappalyzer.analyze({
     url,

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 'use strict'
-
+//test ed
 const { chain, mapValues } = require('lodash')
 const wappalyzer = require('wappalyzer-core')
 const { Cookie } = require('tough-cookie')


### PR DESCRIPTION
Most websites use 'Set-Cookie' as opposed to 'set-cookie'.
Since object keys are case-sensitive, in those cases the cookies were overlooked. 
This commit fixes this issue.