### PR TITLE
docs: category and technology

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ getHTML('https://kikobeats.com', { getBrowserless: require('browserless') })
 // }
 ```
 
+### Categories & Technologies
+
+Category and technology information is mirrored from the wappalyzer repository and stored in `src/*.json`. You do not need to source category and technology information when using this library.
+
 ## License
 
 **simple-wappalyzer** © [Kiko Beats](https://kikobeats.com), released under the [MIT](https://github.com/Kikobeats/simple-wappalyzer/blob/master/LICENSE.md) License.<br>


### PR DESCRIPTION
Without digging into the source, it's not clear that the category & technology information is included in this repo.

In the wappalyzer-core readme, it indicates that `{a-z}.json` files must be downloaded. There isn't a script in this repo
to download these files. How are they downloaded and aggregated into a single file? Why not keep the directory/file stucture
that exists in the wappalyzer-core repo? Curious your thinking here.
